### PR TITLE
Use PropsWithChildren and ComponentPropsWithRef to type accordion header component props

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
@@ -37,11 +37,11 @@ function AccordionHeader({
     'data-index': index,
   });
 
-  const onClick: React.MouseEventHandler<HTMLButtonElement> = useCallback((event) => {
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = useCallback((event) => {
     toggleSection(event.currentTarget.id);
   }, [ toggleSection ]);
 
-  const onKeyDown: React.KeyboardEventHandler<HTMLButtonElement> = useCallback((event) => {
+  const handleKeyDown: React.KeyboardEventHandler<HTMLButtonElement> = useCallback((event) => {
     const { key, currentTarget } = event;
 
     if(!currentTarget.dataset.index)
@@ -75,10 +75,10 @@ function AccordionHeader({
   return (
     <BaseAccordionHeader
       id={ id }
+      onKeyDown={ handleKeyDown }
       controlsId={ getPanelId(id) }
       headerLevel={ headerLevel }
-      onClick={ onClick }
-      onKeyDown={ onKeyDown }
+      onClick={ handleClick }
       isExpanded={ isExpanded }
       isDisabled={ isDisabled }
       headerProps={ headerProps }

--- a/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
@@ -26,6 +26,7 @@ const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHea
   return (
     <HeaderElement { ...headerProps }>
       <button
+        { ...buttonProps }
         type="button"
         id={ id }
         aria-controls={ controlsId }
@@ -34,7 +35,6 @@ const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHea
         aria-expanded={ isExpanded }
         aria-disabled={ isDisabled }
         ref={ ref }
-        { ...buttonProps }
       >
         { children }
       </button>

--- a/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
@@ -12,10 +12,10 @@ import { VALID_HTML_HEADER_LEVELS } from 'src/utils';
 const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHeaderProps>(({
   children,
   id,
+  onKeyDown,
   controlsId,
   headerLevel,
   onClick,
-  onKeyDown,
   isExpanded,
   isDisabled,
   headerProps,
@@ -29,9 +29,9 @@ const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHea
         { ...buttonProps }
         type="button"
         id={ id }
+        onKeyDown={ onKeyDown }
         aria-controls={ controlsId }
         onClick={ onClick }
-        onKeyDown={ onKeyDown }
         aria-expanded={ isExpanded }
         aria-disabled={ isDisabled }
         ref={ ref }
@@ -45,10 +45,10 @@ const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHea
 BaseAccordionHeader.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string,
+  onKeyDown: PropTypes.func,
   controlsId: PropTypes.string.isRequired,
   headerLevel: PropTypes.oneOf(VALID_HTML_HEADER_LEVELS).isRequired,
   onClick: PropTypes.func.isRequired,
-  onKeyDown: PropTypes.func.isRequired,
   isExpanded: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool.isRequired,
   headerProps: PropTypes.object,
@@ -57,6 +57,7 @@ BaseAccordionHeader.propTypes = {
 
 BaseAccordionHeader.defaultProps = {
   id: undefined,
+  onKeyDown: undefined,
   headerProps: {},
   buttonProps: {},
 };

--- a/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
@@ -48,18 +48,15 @@ BaseAccordionHeader.propTypes = {
   controlsId: PropTypes.string.isRequired,
   headerLevel: PropTypes.oneOf(VALID_HTML_HEADER_LEVELS).isRequired,
   onClick: PropTypes.func.isRequired,
-  onKeyDown: PropTypes.func,
-  isExpanded: PropTypes.bool,
-  isDisabled: PropTypes.bool,
+  onKeyDown: PropTypes.func.isRequired,
+  isExpanded: PropTypes.bool.isRequired,
+  isDisabled: PropTypes.bool.isRequired,
   headerProps: PropTypes.object,
   buttonProps: PropTypes.object,
 };
 
 BaseAccordionHeader.defaultProps = {
   id: undefined,
-  onKeyDown: undefined,
-  isExpanded: false,
-  isDisabled: false,
   headerProps: {},
   buttonProps: {},
 };

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -6,7 +6,7 @@ import type {
   ValidHTMLHeaderLevels,
   PolymorphicComponentPropsWithoutRef,
   PolymorphicComponentPropsWithRef,
-  PolymorphicForwardRefComponent,
+  PolymorphicForwardRefComponent
 } from 'src/utils/types';
 
 //Misc.
@@ -120,9 +120,7 @@ export type AccordionPanelProps<C extends ValidPanelElements = typeof DEFAULT_PA
   ValidPanelElements
 >;
 
-export interface BaseAccordionHeaderProps {
-  children: React.ReactNode;
-  id?: string | undefined;
+export interface InternalBaseAccordionHeaderProps {
   controlsId: string;
   headerLevel: ValidHTMLHeaderLevels;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
@@ -131,7 +129,11 @@ export interface BaseAccordionHeaderProps {
   isDisabled?: boolean;
   headerProps?: Props;
   buttonProps?: Props;
-}
+};
+
+export type BaseAccordionHeaderProps =
+  InternalBaseAccordionHeaderProps &
+  Omit<React.ComponentPropsWithRef<"button">, keyof InternalBaseAccordionHeaderProps>;
 
 export interface InternalBaseAccordionPanelProps {
   id: string;

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -6,7 +6,7 @@ import type {
   ValidHTMLHeaderLevels,
   PolymorphicComponentPropsWithoutRef,
   PolymorphicComponentPropsWithRef,
-  PolymorphicForwardRefComponent
+  PolymorphicForwardRefComponent,
 } from 'src/utils/types';
 
 //Misc.
@@ -124,16 +124,15 @@ export interface InternalBaseAccordionHeaderProps {
   controlsId: string;
   headerLevel: ValidHTMLHeaderLevels;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-  onKeyDown: React.KeyboardEventHandler<HTMLButtonElement>;
   isExpanded: boolean;
   isDisabled: boolean;
   headerProps?: Props;
   buttonProps?: Props;
-};
+}
 
 export type BaseAccordionHeaderProps =
   InternalBaseAccordionHeaderProps &
-  Omit<React.ComponentPropsWithRef<"button">, keyof InternalBaseAccordionHeaderProps>;
+  Omit<React.ComponentPropsWithRef<'button'>, keyof InternalBaseAccordionHeaderProps>;
 
 export interface InternalBaseAccordionPanelProps {
   id: string;

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -82,14 +82,14 @@ export interface AccordionMethods {
   focusLastHeader: FocusLastHeader;
 }
 
-export interface AccordionHeaderProps extends
-  Pick<AccordionProps, 'sections' | 'headerLevel'>,
-  Omit<AccordionMethods, 'focusHeader'> {
-  children: React.ReactNode;
-  headerProps?: Props;
-  buttonProps?: Props;
-  index: number;
-}
+export type AccordionHeaderProps =
+  Pick<AccordionProps, 'sections' | 'headerLevel'> &
+  Omit<AccordionMethods, 'focusHeader'> &
+  React.PropsWithChildren<{
+    headerProps?: Props;
+    buttonProps?: Props;
+    index: number;
+  }>;
 
 export type AccordionPanelProps<C extends ValidPanelElements = typeof DEFAULT_PANEL_ELEMENT> = PolymorphicComponentPropsWithoutRef<
   C,

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -124,9 +124,9 @@ export interface InternalBaseAccordionHeaderProps {
   controlsId: string;
   headerLevel: ValidHTMLHeaderLevels;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-  onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement> | undefined;
-  isExpanded?: boolean;
-  isDisabled?: boolean;
+  onKeyDown: React.KeyboardEventHandler<HTMLButtonElement>;
+  isExpanded: boolean;
+  isDisabled: boolean;
   headerProps?: Props;
   buttonProps?: Props;
 };


### PR DESCRIPTION
* Refactor `AccordionHeaderProps` to use `React.PropsWithChildren`
* Refactor `BaseAccordionHeaderProps` to use `React.ComponentPropsWithRef`
* `isExpanded` and `isDisabled` are now required on `BaseAccordionHeaderProps`