### PR TITLE
Stricter typing for headerProps and buttonProps in accordion header components

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 //Components and Styles
@@ -33,9 +33,12 @@ function AccordionHeader({
   const isExpanded = getIsExpanded(id);
   const isDisabled = getIsDisabled(id);
 
-  const _buttonProps = Object.assign({}, buttonProps, {
-    'data-index': index,
-  });
+  const _buttonProps = useMemo(() => {
+    return {
+      ...buttonProps,
+      'data-index': index,
+    };
+  }, [ buttonProps, index ]);
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = useCallback((event) => {
     toggleSection(event.currentTarget.id);

--- a/packages/react-aria-widgets/src/Accordion/BlueAccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BlueAccordionHeader.tsx
@@ -15,7 +15,7 @@ export default function BlueAccordionHeader(props: AccordionHeaderProps) {
     style: {
       ...buttonProps.style,
       color: 'blue',
-    } as unknown,
+    },
   };
 
   return (

--- a/packages/react-aria-widgets/src/Accordion/GreenAccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/GreenAccordionHeader.tsx
@@ -15,7 +15,7 @@ export default function GreenAccordionHeader(props: AccordionHeaderProps) {
     style: {
       ...buttonProps.style,
       color: 'green',
-    } as unknown,
+    },
   };
 
   return (

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -82,16 +82,29 @@ export interface AccordionMethods {
   focusLastHeader: FocusLastHeader;
 }
 
+export type AccordionHeaderHeader = Omit<
+  React.HTMLAttributes<HTMLHeadingElement>,
+  'children' | 'dangerouslySetInnerHTML'
+>;
+
 export type AccordionHeaderButton = Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
-  'type' | 'id' | 'aria-controls' | 'onClick' | 'onKeyDown' | 'aria-expanded' | 'aria-disabled'
+  'children' |
+  'dangerouslySetInnerHTML' |
+  'type' |
+  'id' |
+  'aria-controls' |
+  'onClick' |
+  'onKeyDown' |
+  'aria-expanded' |
+  'aria-disabled'
 >;
 
 export type AccordionHeaderProps =
   Pick<AccordionProps, 'sections' | 'headerLevel'> &
   Omit<AccordionMethods, 'focusHeader'> &
   React.PropsWithChildren<{
-    headerProps?: React.HTMLAttributes<HTMLHeadingElement>;
+    headerProps?: AccordionHeaderHeader;
     buttonProps?: AccordionHeaderButton;
     index: number;
   }>;
@@ -133,7 +146,7 @@ export type BaseAccordionHeaderProps = React.PropsWithChildren<{
   onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement> | undefined;
   isExpanded: boolean;
   isDisabled: boolean;
-  headerProps?: React.HTMLAttributes<HTMLHeadingElement>;
+  headerProps?: AccordionHeaderHeader;
   buttonProps?: AccordionHeaderButton;
 }>;
 

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -82,12 +82,17 @@ export interface AccordionMethods {
   focusLastHeader: FocusLastHeader;
 }
 
+export type AccordionHeaderButton = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'type' | 'id' | 'aria-controls' | 'onClick' | 'onKeyDown' | 'aria-expanded' | 'aria-disabled'
+>;
+
 export type AccordionHeaderProps =
   Pick<AccordionProps, 'sections' | 'headerLevel'> &
   Omit<AccordionMethods, 'focusHeader'> &
   React.PropsWithChildren<{
-    headerProps?: Props;
-    buttonProps?: Props;
+    headerProps?: React.HTMLAttributes<HTMLHeadingElement>;
+    buttonProps?: AccordionHeaderButton;
     index: number;
   }>;
 
@@ -128,8 +133,8 @@ export type BaseAccordionHeaderProps = React.PropsWithChildren<{
   onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement> | undefined;
   isExpanded: boolean;
   isDisabled: boolean;
-  headerProps?: Props;
-  buttonProps?: Props;
+  headerProps?: React.HTMLAttributes<HTMLHeadingElement>;
+  buttonProps?: AccordionHeaderButton;
 }>;
 
 export interface InternalBaseAccordionPanelProps {


### PR DESCRIPTION
For both `AccordionHeader` and `BaseAccordionHeader`, `buttonProps` and `headerProps` are now typed based on the HTML attributes that `<button>` and `<h1>` to `<h6>` can accept.