### PR TITLE
Use useId to generated Accordion IDs

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
@@ -68,7 +68,7 @@ const meta = {
                     <label htmlFor="nestedNameInput">
                       Name:
                     </label>
-                    <input id="nestedNameInputId" type="text" />
+                    <input id="nestedNameInput" type="text" />
                     <button type="submit">
                       Submit
                     </button>

--- a/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
 
     return (
       <Accordion { ...args }>
-        <AccordionSection id="1">
+        <AccordionSection>
           <AccordionHeader>
             Basic Section
           </AccordionHeader>
@@ -29,7 +29,7 @@ const meta = {
             Hello world!
           </AccordionPanel>
         </AccordionSection>
-        <AccordionSection id="2">
+        <AccordionSection>
           <AccordionHeader>
             Section With Interactive Elements
           </AccordionHeader>
@@ -45,13 +45,13 @@ const meta = {
             </form>
           </AccordionPanel>
         </AccordionSection>
-        <AccordionSection id="3">
+        <AccordionSection>
           <AccordionHeader>
             Section With Nested Accordion
           </AccordionHeader>
           <AccordionPanel>
             <Accordion headerLevel={ 2 }>
-              <AccordionSection id="3-1">
+              <AccordionSection>
                 <AccordionHeader>
                   Basic Section
                 </AccordionHeader>
@@ -59,7 +59,7 @@ const meta = {
                   Hello world!
                 </AccordionPanel>
               </AccordionSection>
-              <AccordionSection id="3-2">
+              <AccordionSection>
                 <AccordionHeader>
                   Section With Interactive Elements
                 </AccordionHeader>
@@ -68,7 +68,7 @@ const meta = {
                     <label htmlFor="nestedNameInput">
                       Name:
                     </label>
-                    <input id="nestedNameInput" type="text" />
+                    <input id="nestedNameInputId" type="text" />
                     <button type="submit">
                       Submit
                     </button>
@@ -76,6 +76,22 @@ const meta = {
                 </AccordionPanel>
               </AccordionSection>
             </Accordion>
+          </AccordionPanel>
+        </AccordionSection>
+        <AccordionSection id="manually-entered-id">
+          <AccordionHeader>
+            Section With Manual ID
+          </AccordionHeader>
+          <AccordionPanel>
+            The IDs for accessibility attributes in this section are coming from the
+            { ' ' }
+            <code>id</code>
+            { ' ' }
+            prop, not React&apos;s
+            { ' ' }
+            <code>useId</code>
+            { ' ' }
+            hook.
           </AccordionPanel>
         </AccordionSection>
       </Accordion>

--- a/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
@@ -12,7 +12,7 @@ function AccordionSection({
   id: idProp = undefined,
 }: AccordionSectionProps) {
   const reactGeneratedId = useId();
-  const id = idProp ? idProp: reactGeneratedId;
+  const id = idProp ? idProp : reactGeneratedId;
 
   return (
     <AccordionSectionContext.Provider value={ id }>

--- a/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import PropTypes from 'prop-types';
 
 //Contexts
@@ -9,8 +9,11 @@ import type { AccordionSectionProps } from 'src/Accordion/types';
 
 function AccordionSection({
   children = null,
-  id,
+  id: idProp = undefined,
 }: AccordionSectionProps) {
+  const reactGeneratedId = useId();
+  const id = idProp ? idProp: reactGeneratedId;
+
   return (
     <AccordionSectionContext.Provider value={ id }>
       { children }
@@ -20,7 +23,7 @@ function AccordionSection({
 
 AccordionSection.propTypes = {
   children: PropTypes.node,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
 };
 
 export default AccordionSection;

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -67,7 +67,7 @@ export type AccordionProps = React.PropsWithChildren<{
 }>;
 
 export type AccordionSectionProps = React.PropsWithChildren<{
-  id: string;
+  id?: string;
 }>;
 
 export type AccordionHeaderProps = React.PropsWithChildren<{


### PR DESCRIPTION
Uses `useId` by default to generated IDs for accessibility attributes. `<AccordionSection>` still accepts an `id` prop for those who wish to manually pass in an ID.

Resolves #46 