### PR TITLE
Replace allowToggle with allowCollapseLast

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
@@ -99,31 +99,31 @@ const meta = {
   },
 } satisfies Meta<typeof Accordion>;
 
-export const YesMultipleYesToggle: Story = {
+export const YesMultipleYesCollapseLast: Story = {
   args: {
     allowMultiple: true,
-    allowToggle: true,
+    allowCollapseLast: true,
   },
 };
 
-export const NoMultipleYesToggle: Story = {
+export const NoMultipleYesCollapseLast: Story = {
   args: {
     allowMultiple: false,
-    allowToggle: true,
+    allowCollapseLast: true,
   },
 };
 
-export const YesMultipleNoToggle: Story = {
+export const YesMultipleNoCollapseLast: Story = {
   args: {
     allowMultiple: true,
-    allowToggle: false,
+    allowCollapseLast: false,
   },
 };
 
-export const NoMultipleNoToggle: Story = {
+export const NoMultipleNoCollapseLast: Story = {
   args: {
     allowMultiple: false,
-    allowToggle: false,
+    allowCollapseLast: false,
   },
 };
 

--- a/packages/react-aria-widgets/src/Accordion/Accordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.tsx
@@ -16,10 +16,10 @@ import { VALID_HTML_HEADER_LEVELS } from 'src/utils';
 function Accordion({
   children = null,
   allowMultiple = true,
-  allowToggle = true,
+  allowCollapseLast = true,
   headerLevel,
 }: AccordionProps) {
-  const accordionProperties = useAccordion(allowMultiple, allowToggle);
+  const accordionProperties = useAccordion(allowMultiple, allowCollapseLast);
   const accordionContextValue = useMemo(() => {
     return {
       headerLevel,
@@ -40,7 +40,7 @@ function Accordion({
 Accordion.propTypes = {
   children: PropTypes.node,
   allowMultiple: PropTypes.bool,
-  allowToggle: PropTypes.bool,
+  allowCollapseLast: PropTypes.bool,
   headerLevel: PropTypes.oneOf(VALID_HTML_HEADER_LEVELS).isRequired,
 };
 

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -27,7 +27,7 @@ export type FocusLastHeader = () => void;
 
 export interface AccordionContextType {
   allowMultiple: boolean;
-  allowToggle: boolean;
+  allowCollapseLast: boolean;
   headerLevel: ValidHTMLHeaderLevels;
   getIsExpanded: GetIsExpanded;
   getIsDisabled: GetIsDisabled;
@@ -62,7 +62,7 @@ export type AccordionHeaderButton = Omit<
 
 export type AccordionProps = React.PropsWithChildren<{
   allowMultiple?: boolean;
-  allowToggle?: boolean;
+  allowCollapseLast?: boolean;
   headerLevel: ValidHTMLHeaderLevels;
 }>;
 

--- a/packages/react-aria-widgets/src/Accordion/useAccordion.ts
+++ b/packages/react-aria-widgets/src/Accordion/useAccordion.ts
@@ -18,36 +18,14 @@ function _getIsExpanded(expandedSections: Set<string>, id: string) {
   return expandedSections.has(id);
 }
 
-function _getIsDisabled(allowToggle: boolean, isExpanded: boolean) {
-  return !allowToggle && isExpanded;
+function _getIsDisabled(allowCollapseLast: boolean, isExpanded: boolean) {
+  return !allowCollapseLast && isExpanded;
 }
 
-export default function useAccordion(allowMultiple: boolean, allowToggle: boolean) {
+export default function useAccordion(allowMultiple: boolean, allowCollapseLast: boolean) {
   const [ expandedSections, setExpandedSections ] = useState(new Set<string>());
   const headerRefs = useRef<HeaderRef[]>([]);
   const headerRefIndexMap = useRef<Map<HeaderRef, number>>(new Map());
-
-  /**
-   * Returns a boolean that lets us know if this accordion lets us collapse
-   * an already-expanded accordion section.
-   *
-   * Note that even though this component accepts <code>allowToggle</code> and
-   * <code>allowMultiple</code> as independent booleans, it doesn't reflect
-   * the actual behavior of this accordion implementation.
-   *
-   * Technically speaking, this component can receive props such that
-   * <code>allowMultiple && !allowToggle</code>. But that situation would
-   * allow for opening multiple accordion sections that can't be closed. So,
-   * we force sections to be toggleable if <code>allowMultiple</code> is
-   * <code>true</code>.
-   *
-   * Additionally, child components should use <code>getAllowToggle</code> rather
-   * than directly accessing the <code>allowToggle</code> prop because the getter
-   * reflects the above behavior.
-   */
-  const getAllowToggle = useCallback(() => {
-    return allowMultiple ? true : allowToggle;
-  }, [ allowMultiple, allowToggle ]);
 
   /**
    * Returns a boolean that lets us know if a particular accordion section is
@@ -59,20 +37,20 @@ export default function useAccordion(allowMultiple: boolean, allowToggle: boolea
 
   /**
    * Returns a boolean that lets us know if an aleady-expanded accordion section
-   * can't be collapsed due to <code>allowToggle</code>.
+   * can't be collapsed due to <code>allowCollapseLast</code>.
    */
   const getIsDisabled: GetIsDisabled = useCallback((id) => {
-    return _getIsDisabled(getAllowToggle(), getIsExpanded(id));
-  }, [ getAllowToggle, getIsExpanded ]);
+    return _getIsDisabled(allowCollapseLast, getIsExpanded(id));
+  }, [ allowCollapseLast, getIsExpanded ]);
 
   /**
    * Expands or collapses an accordion section. Respects <code>allowMultiple</code>
-   * and <code>allowToggle</code>.
+   * and <code>allowCollapseLast</code>.
    */
   const toggleSection: ToggleSection = useCallback((id) => {
     setExpandedSections((expandedSections) => {
       const isExpanded = _getIsExpanded(expandedSections, id);
-      const isDisabled = _getIsDisabled(getAllowToggle(), isExpanded);
+      const isDisabled = _getIsDisabled(allowCollapseLast, isExpanded);
 
       if(allowMultiple) {
         if(isExpanded)
@@ -94,7 +72,7 @@ export default function useAccordion(allowMultiple: boolean, allowToggle: boolea
     });
   }, [
     allowMultiple,
-    getAllowToggle,
+    allowCollapseLast,
   ]);
 
   /**
@@ -160,7 +138,7 @@ export default function useAccordion(allowMultiple: boolean, allowToggle: boolea
   return useMemo(() => {
     return {
       allowMultiple,
-      allowToggle: getAllowToggle(),
+      allowCollapseLast,
       getIsExpanded,
       getIsDisabled,
       toggleSection,
@@ -173,7 +151,7 @@ export default function useAccordion(allowMultiple: boolean, allowToggle: boolea
     };
   }, [
     allowMultiple,
-    getAllowToggle,
+    allowCollapseLast,
     getIsExpanded,
     getIsDisabled,
     toggleSection,

--- a/packages/react-aria-widgets/src/Accordion/useAccordion.ts
+++ b/packages/react-aria-widgets/src/Accordion/useAccordion.ts
@@ -50,22 +50,17 @@ export default function useAccordion(allowMultiple: boolean, allowCollapseLast: 
   const toggleSection: ToggleSection = useCallback((id) => {
     setExpandedSections((expandedSections) => {
       const isExpanded = _getIsExpanded(expandedSections, id);
-      const isDisabled = _getIsDisabled(allowCollapseLast, isExpanded);
 
-      if(allowMultiple) {
-        if(isExpanded)
-          expandedSections.delete(id);
-        else
-          expandedSections.add(id);
-      }
+      if(expandedSections.size === 1 && isExpanded && !allowCollapseLast)
+        return expandedSections;
+
+      if(isExpanded)
+        expandedSections.delete(id);
       else {
-        expandedSections.clear();
+        if(!allowMultiple)
+          expandedSections.clear();
 
-        //Expand the section if it was originally collapsed,
-        //or if it shouldn't have been collapsed as a result
-        //of the indiscriminate call to clear() that we just made.
-        if(!isExpanded || isDisabled)
-          expandedSections.add(id);
+        expandedSections.add(id);
       }
 
       return new Set(expandedSections);

--- a/packages/react-aria-widgets/src/Accordion/useAccordion.ts
+++ b/packages/react-aria-widgets/src/Accordion/useAccordion.ts
@@ -18,8 +18,8 @@ function _getIsExpanded(expandedSections: Set<string>, id: string) {
   return expandedSections.has(id);
 }
 
-function _getIsDisabled(allowCollapseLast: boolean, isExpanded: boolean) {
-  return !allowCollapseLast && isExpanded;
+function _getIsDisabled(expandedSections: Set<string>, id: string, allowCollapseLast: boolean) {
+  return expandedSections.size === 1 && _getIsExpanded(expandedSections, id) && !allowCollapseLast;
 }
 
 export default function useAccordion(allowMultiple: boolean, allowCollapseLast: boolean) {
@@ -40,8 +40,8 @@ export default function useAccordion(allowMultiple: boolean, allowCollapseLast: 
    * can't be collapsed due to <code>allowCollapseLast</code>.
    */
   const getIsDisabled: GetIsDisabled = useCallback((id) => {
-    return _getIsDisabled(allowCollapseLast, getIsExpanded(id));
-  }, [ allowCollapseLast, getIsExpanded ]);
+    return _getIsDisabled(expandedSections, id, allowCollapseLast);
+  }, [ expandedSections, allowCollapseLast ]);
 
   /**
    * Expands or collapses an accordion section. Respects <code>allowMultiple</code>
@@ -50,8 +50,9 @@ export default function useAccordion(allowMultiple: boolean, allowCollapseLast: 
   const toggleSection: ToggleSection = useCallback((id) => {
     setExpandedSections((expandedSections) => {
       const isExpanded = _getIsExpanded(expandedSections, id);
+      const isDisabled = _getIsDisabled(expandedSections, id, allowCollapseLast);
 
-      if(expandedSections.size === 1 && isExpanded && !allowCollapseLast)
+      if(isDisabled)
         return expandedSections;
 
       if(isExpanded)


### PR DESCRIPTION
A minor change, but I think `allowCollapseLast` is ultimately a better abstraction than `allowToggle`. Just felt kind of weird that in the case of `allowMultiple && !allowToggle`, `allowToggle` would effectively be treated as `true` anyway.

Resolves #153 