### PR TITLE
Minor QoL changes to creating custom accordions

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/Accordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.tsx
@@ -21,22 +21,13 @@ function Accordion({
   onStateChange = undefined,
   onFocusChange = undefined,
 }: AccordionProps) {
-  const accordionProperties = useAccordion({
+  const accordionContextValue = useAccordion({
     allowMultiple,
     allowCollapseLast,
+    headerLevel,
     onStateChange,
     onFocusChange,
   });
-
-  const accordionContextValue = useMemo(() => {
-    return {
-      headerLevel,
-      ...accordionProperties,
-    };
-  }, [
-    headerLevel,
-    accordionProperties,
-  ]);
 
   return (
     <AccordionProvider value={ accordionContextValue }>

--- a/packages/react-aria-widgets/src/Accordion/Accordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-//Contexts
-import { AccordionProvider } from 'src/Accordion/AccordionContext';
+//Components
+import ControlledAccordion from 'src/Accordion/ControlledAccordion';
 
 //Hooks
 import useAccordion from 'src/Accordion/useAccordion';
@@ -30,9 +30,9 @@ function Accordion({
   });
 
   return (
-    <AccordionProvider value={ accordionContextValue }>
+    <ControlledAccordion contextValue={ accordionContextValue }>
       { children }
-    </AccordionProvider>
+    </ControlledAccordion>
   );
 }
 

--- a/packages/react-aria-widgets/src/Accordion/Accordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 //Contexts
-import AccordionContext from 'src/Accordion/AccordionContext';
+import { AccordionProvider } from 'src/Accordion/AccordionContext';
 
 //Hooks
 import useAccordion from 'src/Accordion/useAccordion';
@@ -39,9 +39,9 @@ function Accordion({
   ]);
 
   return (
-    <AccordionContext.Provider value={ accordionContextValue }>
+    <AccordionProvider value={ accordionContextValue }>
       { children }
-    </AccordionContext.Provider>
+    </AccordionProvider>
   );
 }
 

--- a/packages/react-aria-widgets/src/Accordion/AccordionContext.ts
+++ b/packages/react-aria-widgets/src/Accordion/AccordionContext.ts
@@ -4,5 +4,7 @@ import { createContext } from 'react';
 import type { AccordionContextType } from 'src/Accordion/types';
 
 const AccordionContext = createContext<AccordionContextType | null>(null);
+const AccordionProvider = AccordionContext.Provider;
 
 export default AccordionContext;
+export { AccordionProvider };

--- a/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
@@ -2,7 +2,7 @@ import React, { useId } from 'react';
 import PropTypes from 'prop-types';
 
 //Contexts
-import AccordionSectionContext from 'src/Accordion/AccordionSectionContext';
+import { AccordionSectionProvider } from 'src/Accordion/AccordionSectionContext';
 
 //Types
 import type { AccordionSectionProps } from 'src/Accordion/types';
@@ -15,9 +15,9 @@ function AccordionSection({
   const id = idProp ? idProp : reactGeneratedId;
 
   return (
-    <AccordionSectionContext.Provider value={ id }>
+    <AccordionSectionProvider value={ id }>
       { children }
-    </AccordionSectionContext.Provider>
+    </AccordionSectionProvider>
   );
 }
 

--- a/packages/react-aria-widgets/src/Accordion/AccordionSectionContext.ts
+++ b/packages/react-aria-widgets/src/Accordion/AccordionSectionContext.ts
@@ -4,5 +4,7 @@ import { createContext } from 'react';
 import type { AccordionSectionContextType } from 'src/Accordion/types';
 
 const AccordionSectionContext = createContext<AccordionSectionContextType | null>(null);
+const AccordionSectionProvider = AccordionSectionContext.Provider;
 
 export default AccordionSectionContext;
+export { AccordionSectionProvider };

--- a/packages/react-aria-widgets/src/Accordion/ControlledAccordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/ControlledAccordion.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+//Contexts
+import { AccordionProvider } from 'src/Accordion/AccordionContext';
+
+//Types
+import { ControlledAccordionProps } from 'src/Accordion/types';
+
+function ControlledAccordion({
+  children,
+  contextValue,
+}: ControlledAccordionProps) {
+  return (
+    <AccordionProvider value={ contextValue }>
+      { children }
+    </AccordionProvider>
+  );
+}
+
+export default ControlledAccordion;

--- a/packages/react-aria-widgets/src/Accordion/ControlledAccordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/ControlledAccordion.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { AccordionProvider } from 'src/Accordion/AccordionContext';
 
 //Types
-import { ControlledAccordionProps } from 'src/Accordion/types';
+import type { ControlledAccordionProps } from 'src/Accordion/types';
 
 function ControlledAccordion({
   children,

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -80,6 +80,10 @@ export type AccordionProps = React.PropsWithChildren<{
   onFocusChange?: OnFocusChange;
 }>;
 
+export type ControlledAccordionProps = React.PropsWithChildren<{
+  contextValue: AccordionContextType;
+}>;
+
 export type AccordionSectionProps = React.PropsWithChildren<{
   id?: string;
 }>;

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -32,6 +32,7 @@ export type OnFocusChange = (ref: HeaderRef, index: number) => void;
 export interface UseAccordion {
   allowMultiple: boolean;
   allowCollapseLast: boolean;
+  headerLevel: ValidHTMLHeaderLevels;
   onStateChange?: OnStateChange | undefined;
   onFocusChange?: OnFocusChange | undefined;
 }

--- a/packages/react-aria-widgets/src/Accordion/useAccordion.ts
+++ b/packages/react-aria-widgets/src/Accordion/useAccordion.ts
@@ -28,6 +28,7 @@ function _getIsDisabled(expandedSections: Set<string>, id: string, allowCollapse
 export default function useAccordion({
   allowMultiple,
   allowCollapseLast,
+  headerLevel,
   onStateChange,
   onFocusChange,
 }: UseAccordion) {
@@ -158,6 +159,7 @@ export default function useAccordion({
     return {
       allowMultiple,
       allowCollapseLast,
+      headerLevel,
       getIsExpanded,
       getIsDisabled,
       toggleSection,
@@ -171,6 +173,7 @@ export default function useAccordion({
   }, [
     allowMultiple,
     allowCollapseLast,
+    headerLevel,
     getIsExpanded,
     getIsDisabled,
     toggleSection,


### PR DESCRIPTION
* `useAccordion` now accepts and returns a `headerLevel`
* Context files explicitly export their providers
* Add a new component `<ControlledAccordion>` that's just a thin wrapper over `AccordionContext.Provider`