### PR TITLE
Move Accordion event handlers to useAccordion

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
@@ -23,46 +23,13 @@ function AccordionHeader({
     headerLevel,
     getIsExpanded,
     getIsDisabled,
-    toggleSection,
     pushHeaderRef,
-    focusPrevHeader,
-    focusNextHeader,
-    focusFirstHeader,
-    focusLastHeader,
+    handleClick,
+    handleKeyDown,
   } = useAccordionContext();
   const id = useAccordionSectionContext();
   const isExpanded = getIsExpanded(id);
   const isDisabled = getIsDisabled(id);
-
-  const handleClick: React.MouseEventHandler<HTMLButtonElement> = useCallback((event) => {
-    toggleSection(event.currentTarget.id);
-  }, [ toggleSection ]);
-
-  const handleKeyDown: React.KeyboardEventHandler<HTMLButtonElement> = useCallback((event) => {
-    const { key } = event;
-
-    if(key === 'ArrowUp') {
-      event.preventDefault();
-      focusPrevHeader(event);
-    }
-    else if(key === 'ArrowDown') {
-      event.preventDefault();
-      focusNextHeader(event);
-    }
-    else if(key === 'Home') {
-      event.preventDefault();
-      focusFirstHeader();
-    }
-    else if(key === 'End') {
-      event.preventDefault();
-      focusLastHeader();
-    }
-  }, [
-    focusPrevHeader,
-    focusNextHeader,
-    focusFirstHeader,
-    focusLastHeader,
-  ]);
 
   return (
     <BaseAccordionHeader

--- a/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 //Components

--- a/packages/react-aria-widgets/src/Accordion/ControlledAccordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/ControlledAccordion.tsx
@@ -9,7 +9,7 @@ import type { ControlledAccordionProps } from 'src/Accordion/types';
 import { accordionContextValuePropType } from 'src/Accordion/propTypes';
 
 function ControlledAccordion({
-  children,
+  children = null,
   contextValue,
 }: ControlledAccordionProps) {
   return (

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -28,6 +28,8 @@ export type FocusFirstHeader = () => void;
 export type FocusLastHeader = () => void;
 export type OnStateChange = (expandedSections: ExpandedSections) => void;
 export type OnFocusChange = (ref: HeaderRef, index: number) => void;
+export type HandleClick = React.MouseEventHandler<HTMLElement>;
+export type HandleKeyDown = React.KeyboardEventHandler<HTMLElement>;
 
 export interface UseAccordion {
   allowMultiple: boolean;
@@ -50,6 +52,8 @@ export interface AccordionContextType {
   focusNextHeader: FocusNextHeader;
   focusFirstHeader: FocusFirstHeader;
   focusLastHeader: FocusLastHeader;
+  handleClick: HandleClick;
+  handleKeyDown: HandleKeyDown;
 }
 
 export type AccordionSectionContextType = string;

--- a/packages/react-aria-widgets/src/Accordion/useAccordion.ts
+++ b/packages/react-aria-widgets/src/Accordion/useAccordion.ts
@@ -14,6 +14,8 @@ import type {
   FocusNextHeader,
   FocusFirstHeader,
   FocusLastHeader,
+  HandleClick,
+  HandleKeyDown,
   OnStateChange,
 } from 'src/Accordion/types';
 
@@ -146,6 +148,46 @@ export default function useAccordion({
   const focusLastHeader: FocusLastHeader = useCallback(() => {
     focusHeader(headerRefs.current.length - 1);
   }, [ focusHeader ]);
+  
+  /**
+   * Click event handler for accordion header buttons. Handles basic expand/collapse
+   * behavior. Buttons could potentially be elements with role="button" instead of a
+   * <button>.
+   */
+  const handleClick: HandleClick = useCallback((event) => {
+    toggleSection(event.currentTarget.id);
+  }, [ toggleSection ]);
+  
+  /**
+   * Keyboard event handler for accordion header buttons. Handles basic focus management
+   * as described in the APG. Buttons could potentially be elements with role="button"
+   * instead of a <button>.
+   */
+  const handleKeyDown: HandleKeyDown = useCallback((event) => {
+    const { key } = event;
+
+    if(key === 'ArrowUp') {
+      event.preventDefault();
+      focusPrevHeader(event);
+    }
+    else if(key === 'ArrowDown') {
+      event.preventDefault();
+      focusNextHeader(event);
+    }
+    else if(key === 'Home') {
+      event.preventDefault();
+      focusFirstHeader();
+    }
+    else if(key === 'End') {
+      event.preventDefault();
+      focusLastHeader();
+    }
+  }, [
+    focusPrevHeader,
+    focusNextHeader,
+    focusFirstHeader,
+    focusLastHeader,
+  ]);
 
   useEffect(() => {
     if(typeof onStateChangeRef.current !== 'function')
@@ -169,6 +211,8 @@ export default function useAccordion({
       focusNextHeader,
       focusFirstHeader,
       focusLastHeader,
+      handleClick,
+      handleKeyDown,
     };
   }, [
     allowMultiple,
@@ -183,5 +227,7 @@ export default function useAccordion({
     focusNextHeader,
     focusFirstHeader,
     focusLastHeader,
+    handleClick,
+    handleKeyDown,
   ]);
 }

--- a/packages/react-aria-widgets/src/Accordion/useAccordion.ts
+++ b/packages/react-aria-widgets/src/Accordion/useAccordion.ts
@@ -148,7 +148,7 @@ export default function useAccordion({
   const focusLastHeader: FocusLastHeader = useCallback(() => {
     focusHeader(headerRefs.current.length - 1);
   }, [ focusHeader ]);
-  
+
   /**
    * Click event handler for accordion header buttons. Handles basic expand/collapse
    * behavior. Buttons could potentially be elements with role="button" instead of a
@@ -157,7 +157,7 @@ export default function useAccordion({
   const handleClick: HandleClick = useCallback((event) => {
     toggleSection(event.currentTarget.id);
   }, [ toggleSection ]);
-  
+
   /**
    * Keyboard event handler for accordion header buttons. Handles basic focus management
    * as described in the APG. Buttons could potentially be elements with role="button"


### PR DESCRIPTION
Resolves #152 

Now developers don't need to implement their own event handlers should they wish to create their own accordion header component.