### PR TITLE
Accordion click and keydown event callbacks

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
@@ -145,4 +145,22 @@ export const WithFocusChangeCallback: Story = {
   },
 };
 
+export const WithClickCallback: Story = {
+  args: {
+    onClick: (event) => {
+      //eslint-disable-next-line no-console
+      console.log(event);
+    },
+  },
+};
+
+export const WithKeyDownCallback: Story = {
+  args: {
+    onKeyDown: (event) => {
+     //eslint-disable-next-line no-console
+     console.log(event);
+    },
+  },
+};
+
 export default meta;

--- a/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
@@ -157,8 +157,8 @@ export const WithClickCallback: Story = {
 export const WithKeyDownCallback: Story = {
   args: {
     onKeyDown: (event) => {
-     //eslint-disable-next-line no-console
-     console.log(event);
+      //eslint-disable-next-line no-console
+      console.log(event);
     },
   },
 };

--- a/packages/react-aria-widgets/src/Accordion/Accordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.tsx
@@ -20,6 +20,8 @@ function Accordion({
   headerLevel,
   onStateChange = undefined,
   onFocusChange = undefined,
+  onClick = undefined,
+  onKeyDown = undefined,
 }: AccordionProps) {
   const accordionContextValue = useAccordion({
     allowMultiple,
@@ -27,6 +29,8 @@ function Accordion({
     headerLevel,
     onStateChange,
     onFocusChange,
+    onClick,
+    onKeyDown,
   });
 
   return (
@@ -43,6 +47,8 @@ Accordion.propTypes = {
   headerLevel: PropTypes.oneOf(VALID_HTML_HEADER_LEVELS).isRequired,
   onStateChange: PropTypes.func,
   onFocusChange: PropTypes.func,
+  onClick: PropTypes.func,
+  onKeyDown: PropTypes.func,
 };
 
 export default Accordion;

--- a/packages/react-aria-widgets/src/Accordion/propTypes.ts
+++ b/packages/react-aria-widgets/src/Accordion/propTypes.ts
@@ -16,4 +16,6 @@ export const accordionContextValuePropType = PropTypes.exact({
   focusNextHeader: PropTypes.func.isRequired,
   focusFirstHeader: PropTypes.func.isRequired,
   focusLastHeader: PropTypes.func.isRequired,
+  handleClick: PropTypes.func.isRequired,
+  handleKeyDown: PropTypes.func.isRequired,
 });

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -26,10 +26,12 @@ export type FocusPrevHeader = (event: React.KeyboardEvent<HTMLButtonElement | HT
 export type FocusNextHeader = (event: React.KeyboardEvent<HTMLButtonElement | HTMLElement>) => void;
 export type FocusFirstHeader = () => void;
 export type FocusLastHeader = () => void;
-export type OnStateChange = (expandedSections: ExpandedSections) => void;
-export type OnFocusChange = (ref: HeaderRef, index: number) => void;
 export type HandleClick = React.MouseEventHandler<HTMLElement>;
 export type HandleKeyDown = React.KeyboardEventHandler<HTMLElement>;
+export type OnStateChange = (expandedSections: ExpandedSections) => void;
+export type OnFocusChange = (ref: HeaderRef, index: number) => void;
+export type OnClick = (event: React.MouseEvent<HTMLElement>) => void;
+export type OnKeyDown = (event: React.KeyboardEvent<HTMLElement>) => void;
 
 export interface UseAccordion {
   allowMultiple: boolean;
@@ -37,6 +39,8 @@ export interface UseAccordion {
   headerLevel: ValidHTMLHeaderLevels;
   onStateChange?: OnStateChange | undefined;
   onFocusChange?: OnFocusChange | undefined;
+  onClick?: OnClick | undefined;
+  onKeyDown?: OnKeyDown | undefined;
 }
 
 export interface AccordionContextType {
@@ -82,6 +86,8 @@ export type AccordionProps = React.PropsWithChildren<{
   headerLevel: ValidHTMLHeaderLevels;
   onStateChange?: OnStateChange;
   onFocusChange?: OnFocusChange;
+  onClick?: OnClick;
+  onKeyDown?: OnKeyDown;
 }>;
 
 export type ControlledAccordionProps = React.PropsWithChildren<{

--- a/packages/react-aria-widgets/src/Accordion/useAccordion.ts
+++ b/packages/react-aria-widgets/src/Accordion/useAccordion.ts
@@ -33,6 +33,8 @@ export default function useAccordion({
   headerLevel,
   onStateChange,
   onFocusChange,
+  onClick,
+  onKeyDown,
 }: UseAccordion) {
   const [ expandedSections, setExpandedSections ] = useState<ExpandedSections>(new Set<string>());
   const headerRefs = useRef<HeaderRef[]>([]);
@@ -156,7 +158,10 @@ export default function useAccordion({
    */
   const handleClick: HandleClick = useCallback((event) => {
     toggleSection(event.currentTarget.id);
-  }, [ toggleSection ]);
+
+    if(typeof onClick === 'function')
+      onClick(event);
+  }, [ toggleSection, onClick ]);
 
   /**
    * Keyboard event handler for accordion header buttons. Handles basic focus management
@@ -182,11 +187,15 @@ export default function useAccordion({
       event.preventDefault();
       focusLastHeader();
     }
+
+    if(typeof onKeyDown === 'function')
+      onKeyDown(event);
   }, [
     focusPrevHeader,
     focusNextHeader,
     focusFirstHeader,
     focusLastHeader,
+    onKeyDown,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Allows passing callbacks to `<Accordion>`/`useAccordion` that the built-in click and keydown event handlers execute.