### PR TITLE
Accordion ID refactor and other misc. changes

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
 
     return (
       <Accordion { ...args }>
-        <AccordionSection>
+        <AccordionSection id="section1">
           <AccordionHeader>
             Basic Section
           </AccordionHeader>
@@ -29,7 +29,7 @@ const meta = {
             Hello world!
           </AccordionPanel>
         </AccordionSection>
-        <AccordionSection>
+        <AccordionSection id="section2">
           <AccordionHeader>
             Section With Interactive Elements
           </AccordionHeader>
@@ -45,13 +45,13 @@ const meta = {
             </form>
           </AccordionPanel>
         </AccordionSection>
-        <AccordionSection>
+        <AccordionSection id="section3">
           <AccordionHeader>
             Section With Nested Accordion
           </AccordionHeader>
           <AccordionPanel>
             <Accordion headerLevel={ 2 }>
-              <AccordionSection>
+              <AccordionSection id="nested-section1">
                 <AccordionHeader>
                   Basic Section
                 </AccordionHeader>
@@ -59,7 +59,7 @@ const meta = {
                   Hello world!
                 </AccordionPanel>
               </AccordionSection>
-              <AccordionSection>
+              <AccordionSection id="nested-section2">
                 <AccordionHeader>
                   Section With Interactive Elements
                 </AccordionHeader>
@@ -76,22 +76,6 @@ const meta = {
                 </AccordionPanel>
               </AccordionSection>
             </Accordion>
-          </AccordionPanel>
-        </AccordionSection>
-        <AccordionSection id="manually-entered-id">
-          <AccordionHeader>
-            Section With Manual ID
-          </AccordionHeader>
-          <AccordionPanel>
-            The IDs for accessibility attributes in this section are coming from the
-            { ' ' }
-            <code>id</code>
-            { ' ' }
-            prop, not React&apos;s
-            { ' ' }
-            <code>useId</code>
-            { ' ' }
-            hook.
           </AccordionPanel>
         </AccordionSection>
       </Accordion>
@@ -138,27 +122,9 @@ export const WithStateChangeCallback: Story = {
 
 export const WithFocusChangeCallback: Story = {
   args: {
-    onFocusChange: (ref, index) => {
+    onFocusChange: ({ elem, index, id }) => {
       //eslint-disable-next-line no-console
-      console.log(ref, index);
-    },
-  },
-};
-
-export const WithClickCallback: Story = {
-  args: {
-    onClick: (event) => {
-      //eslint-disable-next-line no-console
-      console.log(event);
-    },
-  },
-};
-
-export const WithKeyDownCallback: Story = {
-  args: {
-    onKeyDown: (event) => {
-      //eslint-disable-next-line no-console
-      console.log(event);
+      console.log(elem, index, id);
     },
   },
 };

--- a/packages/react-aria-widgets/src/Accordion/Accordion.tsx
+++ b/packages/react-aria-widgets/src/Accordion/Accordion.tsx
@@ -20,8 +20,6 @@ function Accordion({
   headerLevel,
   onStateChange = undefined,
   onFocusChange = undefined,
-  onClick = undefined,
-  onKeyDown = undefined,
 }: AccordionProps) {
   const accordionContextValue = useAccordion({
     allowMultiple,
@@ -29,8 +27,6 @@ function Accordion({
     headerLevel,
     onStateChange,
     onFocusChange,
-    onClick,
-    onKeyDown,
   });
 
   return (
@@ -47,8 +43,6 @@ Accordion.propTypes = {
   headerLevel: PropTypes.oneOf(VALID_HTML_HEADER_LEVELS).isRequired,
   onStateChange: PropTypes.func,
   onFocusChange: PropTypes.func,
-  onClick: PropTypes.func,
-  onKeyDown: PropTypes.func,
 };
 
 export default Accordion;

--- a/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 //Components
@@ -20,13 +20,51 @@ function AccordionHeader({
     headerLevel,
     getIsExpanded,
     getIsDisabled,
+    toggleSection,
     pushHeaderRef,
-    handleClick,
-    handleKeyDown,
+    focusPrevHeader,
+    focusNextHeader,
+    focusFirstHeader,
+    focusLastHeader,
   } = useAccordionContext();
   const { id, headerHTMLId, panelHTMLId } = useAccordionSectionContext();
   const isExpanded = getIsExpanded(id);
   const isDisabled = getIsDisabled(id);
+
+  const refCallback = useCallback((ref: HTMLButtonElement | null) => {
+    pushHeaderRef(ref, id);
+  }, [ id, pushHeaderRef ]);
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = useCallback(() => {
+    toggleSection(id);
+  }, [ toggleSection, id ]);
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLButtonElement> = useCallback((event) => {
+    const { key } = event;
+
+    if(key === 'ArrowUp') {
+      event.preventDefault();
+      focusPrevHeader(id);
+    }
+    else if(key === 'ArrowDown') {
+      event.preventDefault();
+      focusNextHeader(id);
+    }
+    else if(key === 'Home') {
+      event.preventDefault();
+      focusFirstHeader();
+    }
+    else if(key === 'End') {
+      event.preventDefault();
+      focusLastHeader();
+    }
+  }, [
+    focusPrevHeader,
+    focusNextHeader,
+    focusFirstHeader,
+    focusLastHeader,
+    id,
+  ]);
 
   return (
     <BaseAccordionHeader
@@ -39,7 +77,7 @@ function AccordionHeader({
       isDisabled={ isDisabled }
       headerProps={ headerProps }
       buttonProps={ buttonProps }
-      ref={ pushHeaderRef }
+      ref={ refCallback }
     >
       { children }
     </BaseAccordionHeader>

--- a/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
@@ -11,9 +11,6 @@ import useAccordionSectionContext from 'src/Accordion/useAccordionSectionContext
 //Types
 import type { AccordionHeaderProps } from 'src/Accordion/types';
 
-//Misc.
-import { getPanelId } from 'src/Accordion/utils';
-
 function AccordionHeader({
   children = null,
   headerProps = {},
@@ -27,14 +24,14 @@ function AccordionHeader({
     handleClick,
     handleKeyDown,
   } = useAccordionContext();
-  const id = useAccordionSectionContext();
+  const { id, headerHTMLId, panelHTMLId } = useAccordionSectionContext();
   const isExpanded = getIsExpanded(id);
   const isDisabled = getIsDisabled(id);
 
   return (
     <BaseAccordionHeader
-      id={ id }
-      controlsId={ getPanelId(id) }
+      id={ headerHTMLId }
+      controlsId={ panelHTMLId }
       headerLevel={ headerLevel }
       onClick={ handleClick }
       onKeyDown={ handleKeyDown }

--- a/packages/react-aria-widgets/src/Accordion/AccordionPanel.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionPanel.tsx
@@ -14,7 +14,7 @@ import useAccordionSectionContext from 'src/Accordion/useAccordionSectionContext
 import type { AccordionPanelProps, ValidPanelElements } from 'src/Accordion/types';
 
 //Misc.
-import { getPanelId, VALID_PANEL_ELEMENTS, DEFAULT_PANEL_ELEMENT } from 'src/Accordion/utils';
+import { VALID_PANEL_ELEMENTS, DEFAULT_PANEL_ELEMENT } from 'src/Accordion/utils';
 
 function AccordionPanel<C extends ValidPanelElements = typeof DEFAULT_PANEL_ELEMENT>({
   children,
@@ -23,15 +23,15 @@ function AccordionPanel<C extends ValidPanelElements = typeof DEFAULT_PANEL_ELEM
   ...rest
 }: AccordionPanelProps<C>) {
   const { getIsExpanded } = useAccordionContext();
-  const id = useAccordionSectionContext();
+  const { id, headerHTMLId, panelHTMLId } = useAccordionSectionContext();
   const Component: ValidPanelElements = as ? as : DEFAULT_PANEL_ELEMENT;
   const isExpanded = getIsExpanded(id);
 
   return (
     <BaseAccordionPanel<typeof Component>
       { ...rest }
-      id={ getPanelId(id) }
-      labelId={ id }
+      id={ panelHTMLId }
+      labelId={ headerHTMLId }
       className={ `${className} ${isExpanded ? '' : 'react-aria-widgets-hidden'}` }
       as={ Component }
     >

--- a/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import React, { useId, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 //Contexts
@@ -9,13 +9,22 @@ import type { AccordionSectionProps } from 'src/Accordion/types';
 
 function AccordionSection({
   children = null,
-  id: idProp = undefined,
+  id,
 }: AccordionSectionProps) {
-  const reactGeneratedId = useId();
-  const id = idProp ? idProp : reactGeneratedId;
+  const reactId = useId();
+  const headerHTMLId = `${reactId}-react-aria-widgets-accordion-header-${id}`;
+  const panelHTMLId = `${reactId}-react-aria-widgets-accordion-panel-${id}`;
+
+  const contextValue = useMemo(() => {
+    return {
+      id,
+      headerHTMLId,
+      panelHTMLId,
+    };
+  }, [ id, reactId ]);
 
   return (
-    <AccordionSectionProvider value={ id }>
+    <AccordionSectionProvider value={ contextValue }>
       { children }
     </AccordionSectionProvider>
   );
@@ -23,7 +32,7 @@ function AccordionSection({
 
 AccordionSection.propTypes = {
   children: PropTypes.node,
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
 };
 
 export default AccordionSection;

--- a/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionSection.tsx
@@ -21,7 +21,11 @@ function AccordionSection({
       headerHTMLId,
       panelHTMLId,
     };
-  }, [ id, reactId ]);
+  }, [
+    id,
+    headerHTMLId,
+    panelHTMLId,
+  ]);
 
   return (
     <AccordionSectionProvider value={ contextValue }>

--- a/packages/react-aria-widgets/src/Accordion/propTypes.ts
+++ b/packages/react-aria-widgets/src/Accordion/propTypes.ts
@@ -11,11 +11,10 @@ export const accordionContextValuePropType = PropTypes.exact({
   getIsDisabled: PropTypes.func.isRequired,
   toggleSection: PropTypes.func.isRequired,
   pushHeaderRef: PropTypes.func.isRequired,
-  focusHeader: PropTypes.func.isRequired,
+  focusHeaderIndex: PropTypes.func.isRequired,
+  focusHeaderId: PropTypes.func.isRequired,
   focusPrevHeader: PropTypes.func.isRequired,
   focusNextHeader: PropTypes.func.isRequired,
   focusFirstHeader: PropTypes.func.isRequired,
   focusLastHeader: PropTypes.func.isRequired,
-  handleClick: PropTypes.func.isRequired,
-  handleKeyDown: PropTypes.func.isRequired,
 });

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -13,25 +13,27 @@ import type { VALID_PANEL_ELEMENTS, DEFAULT_PANEL_ELEMENT } from 'src/Accordion/
 
 export type ExpandedSections = Set<string>;
 
-export type HeaderRef = HTMLButtonElement | HTMLElement | null;
+export type HeaderElement = HTMLButtonElement | HTMLElement | null;
 
 export type ValidPanelElements = typeof VALID_PANEL_ELEMENTS[number];
+
+export interface HeaderRef {
+  elem: HeaderElement;
+  id: string;
+}
 
 export type GetIsExpanded = (id: string) => boolean;
 export type GetIsDisabled = (id: string) => boolean;
 export type ToggleSection = (id: string) => void;
-export type PushHeaderRef = (ref: HeaderRef) => void;
-export type FocusHeader = (index: number) => void;
-export type FocusPrevHeader = (event: React.KeyboardEvent<HTMLButtonElement | HTMLElement>) => void;
-export type FocusNextHeader = (event: React.KeyboardEvent<HTMLButtonElement | HTMLElement>) => void;
+export type PushHeaderRef = (elem: HeaderElement, id: string) => void;
+export type FocusHeaderIndex = (index: number) => void;
+export type FocusHeaderId = (id: string) => void;
+export type FocusPrevHeader = (id: string) => void;
+export type FocusNextHeader = (id: string) => void;
 export type FocusFirstHeader = () => void;
 export type FocusLastHeader = () => void;
-export type HandleClick = React.MouseEventHandler<HTMLElement>;
-export type HandleKeyDown = React.KeyboardEventHandler<HTMLElement>;
 export type OnStateChange = (expandedSections: ExpandedSections) => void;
-export type OnFocusChange = (ref: HeaderRef, index: number) => void;
-export type OnClick = (event: React.MouseEvent<HTMLElement>) => void;
-export type OnKeyDown = (event: React.KeyboardEvent<HTMLElement>) => void;
+export type OnFocusChange = ({ elem, index, id }: { elem: HeaderElement; index: number; id: string }) => void;
 
 export interface UseAccordion {
   allowMultiple: boolean;
@@ -39,8 +41,6 @@ export interface UseAccordion {
   headerLevel: ValidHTMLHeaderLevels;
   onStateChange?: OnStateChange | undefined;
   onFocusChange?: OnFocusChange | undefined;
-  onClick?: OnClick | undefined;
-  onKeyDown?: OnKeyDown | undefined;
 }
 
 export interface AccordionContextType {
@@ -51,13 +51,12 @@ export interface AccordionContextType {
   getIsDisabled: GetIsDisabled;
   toggleSection: ToggleSection;
   pushHeaderRef: PushHeaderRef;
-  focusHeader: FocusHeader;
+  focusHeaderIndex: FocusHeaderIndex;
+  focusHeaderId: FocusHeaderId;
   focusPrevHeader: FocusPrevHeader;
   focusNextHeader: FocusNextHeader;
   focusFirstHeader: FocusFirstHeader;
   focusLastHeader: FocusLastHeader;
-  handleClick: HandleClick;
-  handleKeyDown: HandleKeyDown;
 }
 
 export interface AccordionSectionContextType {
@@ -90,8 +89,6 @@ export type AccordionProps = React.PropsWithChildren<{
   headerLevel: ValidHTMLHeaderLevels;
   onStateChange?: OnStateChange;
   onFocusChange?: OnFocusChange;
-  onClick?: OnClick;
-  onKeyDown?: OnKeyDown;
 }>;
 
 export type ControlledAccordionProps = React.PropsWithChildren<{

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -60,7 +60,11 @@ export interface AccordionContextType {
   handleKeyDown: HandleKeyDown;
 }
 
-export type AccordionSectionContextType = string;
+export interface AccordionSectionContextType {
+  id: string;
+  headerHTMLId: string;
+  panelHTMLId: string;
+}
 
 export type AccordionHeaderHeader = Omit<
   React.HTMLAttributes<HTMLHeadingElement>,
@@ -95,7 +99,7 @@ export type ControlledAccordionProps = React.PropsWithChildren<{
 }>;
 
 export type AccordionSectionProps = React.PropsWithChildren<{
-  id?: string;
+  id: string;
 }>;
 
 export type AccordionHeaderProps = React.PropsWithChildren<{

--- a/packages/react-aria-widgets/src/Accordion/utils.tsx
+++ b/packages/react-aria-widgets/src/Accordion/utils.tsx
@@ -1,9 +1,2 @@
-/**
- * Gets the ID of an accordion panel based on the accordion's ID.
- */
-export function getPanelId(id: string) {
-  return `${id}-panel`;
-}
-
 export const VALID_PANEL_ELEMENTS = [ 'section', 'div' ] as const;
 export const DEFAULT_PANEL_ELEMENT = VALID_PANEL_ELEMENTS[0];


### PR DESCRIPTION
* `<AccordionSection>` now requires an ID
* Removed event callbacks
* Moved event handlers to `<AccordionHeader>`
* Focus methods now (mostly) ID based
* Removed `getPanelId`, just generate the HTML IDs in `<AccordionSection>`