### PR TITLE
Rename props in base accordion components to match the ARIA attributes

### DIFF
--- a/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionHeader.tsx
@@ -142,12 +142,12 @@ function AccordionHeader({
   return (
     <BaseAccordionHeader
       id={ headerHTMLId }
-      controlsId={ panelHTMLId }
       headerLevel={ headerLevel }
       onClick={ handleClick }
       onKeyDown={ handleKeyDown }
-      isExpanded={ isExpanded }
-      isDisabled={ isDisabled }
+      aria-controls={ panelHTMLId }
+      aria-expanded={ isExpanded }
+      aria-disabled={ isDisabled }
       headerProps={ _headerProps }
       buttonProps={ _buttonProps }
       ref={ refCallback }

--- a/packages/react-aria-widgets/src/Accordion/AccordionPanel.tsx
+++ b/packages/react-aria-widgets/src/Accordion/AccordionPanel.tsx
@@ -63,7 +63,7 @@ function AccordionPanel<C extends ValidPanelElements = typeof DEFAULT_PANEL_ELEM
     <BaseAccordionPanel<typeof Component>
       { ...rest }
       id={ panelHTMLId }
-      labelId={ headerHTMLId }
+      aria-labelledby={ headerHTMLId }
       className={ _className }
       style={ _style }
       as={ Component }

--- a/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.stories.tsx
@@ -10,23 +10,23 @@ const meta = {
   args: {
     children: 'Hello world!',
     id: 'headerId',
-    controlsId: 'panelId',
     headerLevel: 1,
     onClick: (event) => event.preventDefault(),
-    isExpanded: false,
-    isDisabled: false,
+    'aria-controls': 'panelId',
+    'aria-expanded': false,
+    'aria-disabled': false,
   },
 } satisfies Meta<typeof BaseAccordionHeader>;
 
 export const Expanded: Story = {
   args: {
-    isExpanded: true,
+    'aria-expanded': true,
   },
 };
 
 export const Disabled: Story = {
   args: {
-    isDisabled: true,
+    'aria-disabled': true,
   },
 };
 

--- a/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BaseAccordionHeader.tsx
@@ -12,12 +12,12 @@ import { VALID_HTML_HEADER_LEVELS } from 'src/utils';
 const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHeaderProps>(({
   children,
   id,
-  controlsId,
   headerLevel,
   onClick,
   onKeyDown,
-  isExpanded,
-  isDisabled,
+  'aria-controls': ariaControls,
+  'aria-expanded': ariaExpanded,
+  'aria-disabled': ariaDisabled,
   headerProps,
   buttonProps,
 }, ref) => {
@@ -29,11 +29,11 @@ const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHea
         { ...buttonProps }
         type="button"
         id={ id }
-        aria-controls={ controlsId }
         onClick={ onClick }
         onKeyDown={ onKeyDown }
-        aria-expanded={ isExpanded }
-        aria-disabled={ isDisabled }
+        aria-controls={ ariaControls }
+        aria-expanded={ ariaExpanded }
+        aria-disabled={ ariaDisabled }
         ref={ ref }
       >
         { children }
@@ -45,12 +45,12 @@ const BaseAccordionHeader = React.forwardRef<HTMLButtonElement, BaseAccordionHea
 BaseAccordionHeader.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string,
-  controlsId: PropTypes.string.isRequired,
   headerLevel: PropTypes.oneOf(VALID_HTML_HEADER_LEVELS).isRequired,
   onClick: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func,
-  isExpanded: PropTypes.bool.isRequired,
-  isDisabled: PropTypes.bool.isRequired,
+  'aria-controls': PropTypes.string.isRequired,
+  'aria-expanded': PropTypes.bool.isRequired,
+  'aria-disabled': PropTypes.bool.isRequired,
   headerProps: PropTypes.object,
   buttonProps: PropTypes.object,
 };

--- a/packages/react-aria-widgets/src/Accordion/BaseAccordionPanel.stories.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BaseAccordionPanel.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   args: {
     children: 'Hello world!',
     id: 'panelId',
-    labelId: 'labelId',
+    'aria-labelledby': 'labelId',
   },
 } satisfies Meta<typeof BaseAccordionPanel>;
 

--- a/packages/react-aria-widgets/src/Accordion/BaseAccordionPanel.tsx
+++ b/packages/react-aria-widgets/src/Accordion/BaseAccordionPanel.tsx
@@ -15,7 +15,7 @@ function BaseAccordionPanel<C extends React.ElementType = typeof DEFAULT_PANEL_E
     children,
     as,
     id,
-    labelId,
+    'aria-labelledby': ariaLabelledBy,
     ...rest
   }: BaseAccordionPanelProps<C>,
   ref: PolymorphicRef<C>
@@ -26,7 +26,7 @@ function BaseAccordionPanel<C extends React.ElementType = typeof DEFAULT_PANEL_E
     <Component
       { ...rest }
       id={ id }
-      aria-labelledby={ labelId }
+      aria-labelledby={ ariaLabelledBy }
       ref={ ref }
     >
       { children }
@@ -40,7 +40,7 @@ ForwardedBaseAccordionPanel.propTypes = {
   children: PropTypes.node,
   as: PropTypes.oneOf(VALID_PANEL_ELEMENTS),
   id: PropTypes.string.isRequired,
-  labelId: PropTypes.string,
+  'aria-labelledby': PropTypes.string,
 };
 
 ForwardedBaseAccordionPanel.defaultProps = {

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -149,12 +149,12 @@ export type AccordionPanelProps<C extends ValidPanelElements = typeof DEFAULT_PA
 
 export type BaseAccordionHeaderProps = React.PropsWithChildren<{
   id?: string | undefined;
-  controlsId: string;
   headerLevel: ValidHTMLHeaderLevels;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement> | undefined;
-  isExpanded: boolean;
-  isDisabled: boolean;
+  'aria-controls': string;
+  'aria-expanded': boolean;
+  'aria-disabled': boolean;
   headerProps?: BaseHeaderProps;
   buttonProps?: BaseButtonProps;
 }>;

--- a/packages/react-aria-widgets/src/Accordion/types.ts
+++ b/packages/react-aria-widgets/src/Accordion/types.ts
@@ -161,7 +161,7 @@ export type BaseAccordionHeaderProps = React.PropsWithChildren<{
 
 export interface InternalBaseAccordionPanelProps {
   id: string;
-  labelId?: string;
+  'aria-labelledby'?: string;
 }
 
 export type BaseAccordionPanelProps<C extends React.ElementType = typeof DEFAULT_PANEL_ELEMENT> = PolymorphicComponentPropsWithRef<


### PR DESCRIPTION
Resolves #160 